### PR TITLE
feat: add pool latency monitor and graph with alert threshold

### DIFF
--- a/alembic/versions/002_add_response_time.py
+++ b/alembic/versions/002_add_response_time.py
@@ -1,0 +1,47 @@
+"""Add response_time column to reading table
+
+Revision ID: 002_add_response_time
+Revises: 001_add_error_percentage
+Create Date: 2026-01-20 15:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '002_add_response_time'
+down_revision = '001_add_error_percentage'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Check if column already exists before adding it
+    # This makes migration idempotent and safe for existing databases
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    
+    # Check if reading table exists
+    if 'reading' in inspector.get_table_names():
+        columns = [col['name'] for col in inspector.get_columns('reading')]
+        
+        if 'response_time' not in columns:
+            # SQLite: Add column as nullable with default
+            # SQLite will set default value for existing rows
+            # Application code already handles None values (see webapp.py)
+            op.add_column('reading', sa.Column('response_time', sa.Float(), nullable=True, server_default=sa.text('NULL')))
+            # Note: We don't set a default value since response_time may not be available
+            # for older firmware versions or API versions
+
+
+def downgrade() -> None:
+    # Check if column exists before removing it
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    
+    if 'reading' in inspector.get_table_names():
+        columns = [col['name'] for col in inspector.get_columns('reading')]
+        
+        if 'response_time' in columns:
+            op.drop_column('reading', 'response_time')

--- a/bitaxe_sentry/sentry/__main__.py
+++ b/bitaxe_sentry/sentry/__main__.py
@@ -89,16 +89,17 @@ def main():
     signal.signal(signal.SIGHUP, handle_sighup)
     logger.info("Registered SIGHUP handler for configuration reload")
     
-    # Create scheduler
+    # Create scheduler with misfire handling
     global scheduler, current_poll_interval
     scheduler = BackgroundScheduler()
     
-    # Add jobs
+    # Add jobs with misfire_grace_time to handle delayed jobs gracefully
     scheduler.add_job(
         poll_once, 
         'interval', 
         minutes=POLL_INTERVAL, 
-        id='poller'
+        id='poller',
+        misfire_grace_time=300  # Allow up to 5 minutes grace time for missed jobs
     )
     scheduler.add_job(clean_old, 'cron', hour=0, id='cleaner')
     

--- a/bitaxe_sentry/sentry/config.py
+++ b/bitaxe_sentry/sentry/config.py
@@ -17,6 +17,7 @@ TEMP_MIN = settings["TEMP_MIN"]
 TEMP_MAX = settings["TEMP_MAX"]
 VOLT_MIN = settings["VOLT_MIN"]
 LATENCY_MAX_THRESHOLD = settings["LATENCY_MAX_THRESHOLD"]
+LATENCY_CONSECUTIVE_COUNT = settings["LATENCY_CONSECUTIVE_COUNT"]
 
 # Process endpoints
 ENDPOINTS = []
@@ -56,7 +57,7 @@ last_modified_time = get_config_mtime()
 
 def reload_config():
     """Reload configuration from JSON config file if it has been modified"""
-    global POLL_INTERVAL, RETENTION_DAYS, TEMP_MIN, TEMP_MAX, VOLT_MIN, LATENCY_MAX_THRESHOLD, ENDPOINTS, DISCORD_WEBHOOK, last_modified_time
+    global POLL_INTERVAL, RETENTION_DAYS, TEMP_MIN, TEMP_MAX, VOLT_MIN, LATENCY_MAX_THRESHOLD, LATENCY_CONSECUTIVE_COUNT, ENDPOINTS, DISCORD_WEBHOOK, last_modified_time
     
     # Check if the config file has been modified
     current_mtime = get_config_mtime()
@@ -76,6 +77,7 @@ def reload_config():
     TEMP_MAX = settings["TEMP_MAX"]
     VOLT_MIN = settings["VOLT_MIN"]
     LATENCY_MAX_THRESHOLD = settings["LATENCY_MAX_THRESHOLD"]
+    LATENCY_CONSECUTIVE_COUNT = settings["LATENCY_CONSECUTIVE_COUNT"]
     DISCORD_WEBHOOK = settings["DISCORD_WEBHOOK_URL"]
     
     # Process endpoints
@@ -97,6 +99,7 @@ def reload_config():
     logger.info(f"- Temperature range: {TEMP_MIN}°C - {TEMP_MAX}°C")
     logger.info(f"- Minimum voltage: {VOLT_MIN}V")
     logger.info(f"- Maximum latency threshold: {LATENCY_MAX_THRESHOLD}ms")
+    logger.info(f"- Consecutive latency count: {LATENCY_CONSECUTIVE_COUNT}")
     logger.info(f"- Endpoints: {ENDPOINTS}")
     
     # Log Discord webhook status

--- a/bitaxe_sentry/sentry/config.py
+++ b/bitaxe_sentry/sentry/config.py
@@ -16,6 +16,7 @@ RETENTION_DAYS = settings["RETENTION_DAYS"]
 TEMP_MIN = settings["TEMP_MIN"]
 TEMP_MAX = settings["TEMP_MAX"]
 VOLT_MIN = settings["VOLT_MIN"]
+LATENCY_MAX_THRESHOLD = settings["LATENCY_MAX_THRESHOLD"]
 
 # Process endpoints
 ENDPOINTS = []
@@ -55,7 +56,7 @@ last_modified_time = get_config_mtime()
 
 def reload_config():
     """Reload configuration from JSON config file if it has been modified"""
-    global POLL_INTERVAL, RETENTION_DAYS, TEMP_MIN, TEMP_MAX, VOLT_MIN, ENDPOINTS, DISCORD_WEBHOOK, last_modified_time
+    global POLL_INTERVAL, RETENTION_DAYS, TEMP_MIN, TEMP_MAX, VOLT_MIN, LATENCY_MAX_THRESHOLD, ENDPOINTS, DISCORD_WEBHOOK, last_modified_time
     
     # Check if the config file has been modified
     current_mtime = get_config_mtime()
@@ -74,6 +75,7 @@ def reload_config():
     TEMP_MIN = settings["TEMP_MIN"]
     TEMP_MAX = settings["TEMP_MAX"]
     VOLT_MIN = settings["VOLT_MIN"]
+    LATENCY_MAX_THRESHOLD = settings["LATENCY_MAX_THRESHOLD"]
     DISCORD_WEBHOOK = settings["DISCORD_WEBHOOK_URL"]
     
     # Process endpoints
@@ -94,6 +96,7 @@ def reload_config():
     logger.info(f"- Retention days: {RETENTION_DAYS}")
     logger.info(f"- Temperature range: {TEMP_MIN}°C - {TEMP_MAX}°C")
     logger.info(f"- Minimum voltage: {VOLT_MIN}V")
+    logger.info(f"- Maximum latency threshold: {LATENCY_MAX_THRESHOLD}ms")
     logger.info(f"- Endpoints: {ENDPOINTS}")
     
     # Log Discord webhook status

--- a/bitaxe_sentry/sentry/db.py
+++ b/bitaxe_sentry/sentry/db.py
@@ -38,7 +38,7 @@ class Reading(SQLModel, table=True):
     best_diff: str
     voltage: float = Field(default=0.0)  # Voltage in millivolts
     error_percentage: float = Field(default=0.0)  # Error percentage
-    # Additional fields can be added here as needed
+    response_time: float = Field(default=None, nullable=True)  # Pool latency in milliseconds
 
 
 # Create SQLite engine

--- a/bitaxe_sentry/sentry/notifier.py
+++ b/bitaxe_sentry/sentry/notifier.py
@@ -409,4 +409,49 @@ def send_miner_offline_alert(miner):
         return True
     except Exception as e:
         logger.error(f"Failed to send offline alert: {e}")
-        return False 
+        return False
+
+def send_latency_alert(miner, reading):
+    """
+    Send high pool latency alert via Discord webhook.
+    
+    Args:
+        miner: The miner instance
+        reading: Reading instance with response_time data
+        
+    Returns:
+        bool: True if notification was sent successfully, False otherwise
+    """
+    # Check if notifications are muted for this miner
+    if is_miner_muted(miner.id):
+        logger.info(f"Miner {miner.name} (ID: {miner.id}) notifications are muted, skipping latency alert")
+        return False
+    
+    # Reload config to ensure we have the latest webhook URL
+    reload_config()
+    from .config import DISCORD_WEBHOOK, LATENCY_MAX_THRESHOLD
+    
+    if not DISCORD_WEBHOOK:
+        logger.warning(f"Discord webhook URL not configured, skipping latency alert for {miner.name}")
+        return False
+        
+    logger.info(f"Preparing to send latency alert for {miner.name} via webhook: {DISCORD_WEBHOOK[:20]}...")
+    
+    content = (
+      f"⚠️ **{miner.name}** high pool latency detected\n"
+      f"Pool Latency: {reading.response_time:.2f}ms (threshold: {LATENCY_MAX_THRESHOLD}ms)\n"
+      f"This may indicate network issues or pool connectivity problems."
+    )
+    
+    try:
+        response = requests.post(
+            DISCORD_WEBHOOK, 
+            json={"content": content},
+            timeout=10
+        )
+        response.raise_for_status()
+        logger.info(f"Latency alert sent for {miner.name}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to send latency alert: {e}")
+        return False

--- a/bitaxe_sentry/sentry/notifier.py
+++ b/bitaxe_sentry/sentry/notifier.py
@@ -411,13 +411,14 @@ def send_miner_offline_alert(miner):
         logger.error(f"Failed to send offline alert: {e}")
         return False
 
-def send_latency_alert(miner, reading):
+def send_latency_alert(miner, reading, consecutive_count=1):
     """
     Send high pool latency alert via Discord webhook.
     
     Args:
         miner: The miner instance
         reading: Reading instance with response_time data
+        consecutive_count: Number of consecutive high latency readings that triggered the alert
         
     Returns:
         bool: True if notification was sent successfully, False otherwise
@@ -438,7 +439,7 @@ def send_latency_alert(miner, reading):
     logger.info(f"Preparing to send latency alert for {miner.name} via webhook: {DISCORD_WEBHOOK[:20]}...")
     
     content = (
-      f"⚠️ **{miner.name}** high pool latency detected\n"
+      f"⚠️ **{miner.name}** high pool latency detected ({consecutive_count} consecutive)\n"
       f"Pool Latency: {reading.response_time:.2f}ms (threshold: {LATENCY_MAX_THRESHOLD}ms)\n"
       f"This may indicate network issues or pool connectivity problems."
     )

--- a/bitaxe_sentry/sentry/poller.py
+++ b/bitaxe_sentry/sentry/poller.py
@@ -4,11 +4,13 @@ import logging
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from sqlmodel import Session, select
-from .config import ENDPOINTS, TEMP_MAX, TEMP_MIN, VOLT_MIN, LATENCY_MAX_THRESHOLD, reload_config
+from .config import ENDPOINTS, TEMP_MAX, TEMP_MIN, VOLT_MIN, LATENCY_MAX_THRESHOLD, LATENCY_CONSECUTIVE_COUNT, reload_config
 from .db import engine, Miner, Reading
 from .notifier import send_temperature_alert, send_voltage_alert, send_diff_alert, send_miner_offline_alert, send_latency_alert
 
 logger = logging.getLogger(__name__)
+
+consecutive_latency_failures: dict[int, int] = {}
 
 def poll_endpoint(endpoint_url):
     """
@@ -186,16 +188,22 @@ def poll_once():
             else:
                 logger.info(f"Voltage OK for {miner.name}: {r.voltage}V (min: {VOLT_MIN}V)")
             
-            # Latency alerts - check if response time exceeds threshold
-            if r.response_time is not None and r.response_time > LATENCY_MAX_THRESHOLD:
-                logger.warning(f"Pool latency above threshold for {miner.name}: {r.response_time}ms (threshold: {LATENCY_MAX_THRESHOLD}ms)")
-                try:
-                    send_latency_alert(miner, r)
-                    logger.info(f"Latency alert sent for {miner.name}")
-                except Exception as e:
-                    logger.exception(f"Failed to send latency alert for {miner.name}: {e}")
-            else:
-                if r.response_time is not None:
+            # Latency alerts - check for consecutive high latency readings
+            if r.response_time is not None:
+                if r.response_time > LATENCY_MAX_THRESHOLD:
+                    consecutive_latency_failures[miner.id] = consecutive_latency_failures.get(miner.id, 0) + 1
+                    logger.warning(f"Pool latency above threshold for {miner.name}: {r.response_time}ms (threshold: {LATENCY_MAX_THRESHOLD}ms) [consecutive: {consecutive_latency_failures[miner.id]}]")
+                    if consecutive_latency_failures[miner.id] >= LATENCY_CONSECUTIVE_COUNT:
+                        try:
+                            send_latency_alert(miner, r, consecutive_latency_failures[miner.id])
+                            logger.info(f"Latency alert sent for {miner.name}")
+                        except Exception as e:
+                            logger.exception(f"Failed to send latency alert for {miner.name}: {e}")
+                        consecutive_latency_failures[miner.id] = 0
+                else:
+                    if miner.id in consecutive_latency_failures:
+                        logger.info(f"Pool latency returned to normal for {miner.name}, resetting consecutive failure count from {consecutive_latency_failures[miner.id]}")
+                    consecutive_latency_failures[miner.id] = 0
                     logger.info(f"Pool latency OK for {miner.name}: {r.response_time}ms (threshold: {LATENCY_MAX_THRESHOLD}ms)")
             
             # New best diff check

--- a/bitaxe_sentry/sentry/poller.py
+++ b/bitaxe_sentry/sentry/poller.py
@@ -2,12 +2,33 @@ import requests
 import datetime
 import logging
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from sqlmodel import Session, select
-from .config import ENDPOINTS, TEMP_MAX, TEMP_MIN, VOLT_MIN, reload_config
+from .config import ENDPOINTS, TEMP_MAX, TEMP_MIN, VOLT_MIN, LATENCY_MAX_THRESHOLD, reload_config
 from .db import engine, Miner, Reading
-from .notifier import send_temperature_alert, send_voltage_alert, send_diff_alert, send_miner_offline_alert
+from .notifier import send_temperature_alert, send_voltage_alert, send_diff_alert, send_miner_offline_alert, send_latency_alert
 
 logger = logging.getLogger(__name__)
+
+def poll_endpoint(endpoint_url):
+    """
+    Poll a single miner endpoint and return the raw data.
+    Returns a dict with 'success', 'endpoint', 'data' or 'error'.
+    """
+    try:
+        resp = requests.get(f"{endpoint_url}/api/system/info", timeout=10)
+        resp.raise_for_status()
+        return {
+            'success': True,
+            'endpoint': endpoint_url,
+            'data': resp.json()
+        }
+    except Exception as e:
+        return {
+            'success': False,
+            'endpoint': endpoint_url,
+            'error': str(e)
+        }
 
 def normalize_difficulty(diff_value):
     """
@@ -66,6 +87,7 @@ def poll_once():
     """
     Poll all configured miner endpoints once and store results.
     Send alerts if thresholds are exceeded.
+    Polls all miners in parallel for better performance.
     """
     logger.info("Starting polling cycle")
     
@@ -73,7 +95,7 @@ def poll_once():
     reload_config()
     
     # Get the latest thresholds after reload
-    from .config import ENDPOINTS, TEMP_MAX, TEMP_MIN, VOLT_MIN
+    from .config import ENDPOINTS, TEMP_MAX, TEMP_MIN, VOLT_MIN, LATENCY_MAX_THRESHOLD
     
     # Check if there are any endpoints configured
     if not ENDPOINTS:
@@ -82,93 +104,114 @@ def poll_once():
         
     success_count = 0
     
-    with Session(engine) as session:
-        for endpoint_url in ENDPOINTS:
-            try:
-                # Get or create miner record
-                miner = session.exec(select(Miner).where(Miner.endpoint == endpoint_url)).first()
-                if not miner:
-                    logger.info(f"Registering new miner at {endpoint_url}")
-                    miner = Miner(name=f"bitaxe_{endpoint_url.split('://')[-1]}", endpoint=endpoint_url)
-                    session.add(miner)
-                    session.commit()
-                    # Refresh to get the ID
-                    session.refresh(miner)
-                
-                # Poll miner API
-                logger.info(f"Polling miner at {endpoint_url}")
-                resp = requests.get(f"{endpoint_url}/api/system/info", timeout=10)
-                resp.raise_for_status()
-                data = resp.json()
-                
-                # Log raw voltage data for debugging
-                raw_voltage = data.get("voltage", 0.0)
-                converted_voltage = raw_voltage / 1000.0 if raw_voltage else 0.0
-                logger.info(f"Raw voltage: {raw_voltage}, Converted: {converted_voltage}V, Min threshold: {VOLT_MIN}V")
-                
-                # Normalize difficulty to handle both old and new firmware formats
-                raw_best_diff = data.get("bestDiff", "0")
-                normalized_best_diff = normalize_difficulty(raw_best_diff)
-                logger.info(f"Raw best diff: {raw_best_diff}, Normalized: {normalized_best_diff}")
-                
-                # Create reading
-                r = Reading(
-                    miner_id=miner.id,
-                    hash_rate=data["hashRate"],
-                    temperature=data["temp"],
-                    best_diff=normalized_best_diff,
-                    voltage=converted_voltage,  # Convert from millivolts to volts
-                    error_percentage=data.get("errorPercentage", 0.0)  # Error percentage
-                )
-                session.add(r)
-                session.commit()
+    # Poll all endpoints in parallel
+    poll_results = []
+    with ThreadPoolExecutor(max_workers=len(ENDPOINTS)) as executor:
+        futures = {executor.submit(poll_endpoint, ep): ep for ep in ENDPOINTS}
+        for future in as_completed(futures):
+            result = future.result()
+            poll_results.append(result)
+            if result['success']:
                 success_count += 1
+    
+    # Process results and send alerts
+    with Session(engine) as session:
+        for result in poll_results:
+            endpoint_url = result['endpoint']
+            
+            if not result['success']:
+                logger.error(f"Failed to poll miner at {endpoint_url}: {result['error']}")
                 
-                # Temperature alerts
-                if r.temperature > TEMP_MAX or r.temperature < TEMP_MIN:
-                    logger.warning(f"Temperature out of range for {miner.name}: {r.temperature}°C (range: {TEMP_MIN}-{TEMP_MAX}°C)")
-                    send_temperature_alert(miner, r)
-                
-                # Voltage alerts
-                if r.voltage < VOLT_MIN:
-                    logger.warning(f"Voltage below minimum for {miner.name}: {r.voltage}V (min: {VOLT_MIN}V)")
-                    try:
-                        send_voltage_alert(miner, r)
-                        logger.info(f"Voltage alert sent for {miner.name}")
-                    except Exception as e:
-                        logger.exception(f"Failed to send voltage alert for {miner.name}: {e}")
-                else:
-                    logger.info(f"Voltage OK for {miner.name}: {r.voltage}V (min: {VOLT_MIN}V)")
-                
-                # New best diff check
-                prev_reading = session.exec(
-                    select(Reading)
-                    .where(Reading.miner_id == miner.id, Reading.id != r.id)
-                    .order_by(Reading.timestamp.desc())
-                    .limit(1)
-                ).first()
-                
-                # Normalize both values for comparison to handle mixed old/new format data
-                if prev_reading:
-                    prev_normalized = normalize_difficulty(prev_reading.best_diff)
-                    new_normalized = normalize_difficulty(r.best_diff)
-                    if prev_normalized != new_normalized:
-                        logger.info(f"New best diff for {miner.name}: {new_normalized} (was {prev_normalized})")
-                        send_diff_alert(miner, r)
-                    
-            except requests.exceptions.RequestException as e:
-                logger.error(f"Failed to poll miner at {endpoint_url}: {e}")
-                
-                # Send offline alert when miner fails to respond
+                # Get or create miner record for offline alert
+                miner = session.exec(select(Miner).where(Miner.endpoint == endpoint_url)).first()
                 if miner:
                     logger.warning(f"Miner {miner.name} appears to be offline, sending alert")
                     try:
                         send_miner_offline_alert(miner)
                     except Exception as alert_error:
                         logger.exception(f"Failed to send offline alert for {miner.name}: {alert_error}")
-                        
-            except Exception as e:
-                logger.exception(f"Error processing miner at {endpoint_url}: {e}")
+                continue
+            
+            # Get or create miner record
+            miner = session.exec(select(Miner).where(Miner.endpoint == endpoint_url)).first()
+            if not miner:
+                logger.info(f"Registering new miner at {endpoint_url}")
+                miner = Miner(name=f"bitaxe_{endpoint_url.split('://')[-1]}", endpoint=endpoint_url)
+                session.add(miner)
+                session.commit()
+                session.refresh(miner)
+            
+            data = result['data']
+            
+            # Log raw voltage data for debugging
+            raw_voltage = data.get("voltage", 0.0)
+            converted_voltage = raw_voltage / 1000.0 if raw_voltage else 0.0
+            logger.info(f"Raw voltage: {raw_voltage}, Converted: {converted_voltage}V, Min threshold: {VOLT_MIN}V")
+            
+            # Extract pool latency (responseTime in milliseconds)
+            response_time = data.get("responseTime", None)
+            logger.info(f"Pool latency: {response_time}ms" if response_time is not None else "Pool latency: not available")
+            
+            # Normalize difficulty to handle both old and new firmware formats
+            raw_best_diff = data.get("bestDiff", "0")
+            normalized_best_diff = normalize_difficulty(raw_best_diff)
+            logger.info(f"Raw best diff: {raw_best_diff}, Normalized: {normalized_best_diff}")
+            
+            # Create reading
+            r = Reading(
+                miner_id=miner.id,
+                hash_rate=data["hashRate"],
+                temperature=data["temp"],
+                best_diff=normalized_best_diff,
+                voltage=converted_voltage,
+                error_percentage=data.get("errorPercentage", 0.0),
+                response_time=response_time
+            )
+            session.add(r)
+            session.commit()
+            
+            # Temperature alerts
+            if r.temperature > TEMP_MAX or r.temperature < TEMP_MIN:
+                logger.warning(f"Temperature out of range for {miner.name}: {r.temperature}°C (range: {TEMP_MIN}-{TEMP_MAX}°C)")
+                send_temperature_alert(miner, r)
+            
+            # Voltage alerts
+            if r.voltage < VOLT_MIN:
+                logger.warning(f"Voltage below minimum for {miner.name}: {r.voltage}V (min: {VOLT_MIN}V)")
+                try:
+                    send_voltage_alert(miner, r)
+                    logger.info(f"Voltage alert sent for {miner.name}")
+                except Exception as e:
+                    logger.exception(f"Failed to send voltage alert for {miner.name}: {e}")
+            else:
+                logger.info(f"Voltage OK for {miner.name}: {r.voltage}V (min: {VOLT_MIN}V)")
+            
+            # Latency alerts - check if response time exceeds threshold
+            if r.response_time is not None and r.response_time > LATENCY_MAX_THRESHOLD:
+                logger.warning(f"Pool latency above threshold for {miner.name}: {r.response_time}ms (threshold: {LATENCY_MAX_THRESHOLD}ms)")
+                try:
+                    send_latency_alert(miner, r)
+                    logger.info(f"Latency alert sent for {miner.name}")
+                except Exception as e:
+                    logger.exception(f"Failed to send latency alert for {miner.name}: {e}")
+            else:
+                if r.response_time is not None:
+                    logger.info(f"Pool latency OK for {miner.name}: {r.response_time}ms (threshold: {LATENCY_MAX_THRESHOLD}ms)")
+            
+            # New best diff check
+            prev_reading = session.exec(
+                select(Reading)
+                .where(Reading.miner_id == miner.id, Reading.id != r.id)
+                .order_by(Reading.timestamp.desc())
+                .limit(1)
+            ).first()
+            
+            if prev_reading:
+                prev_normalized = normalize_difficulty(prev_reading.best_diff)
+                new_normalized = normalize_difficulty(r.best_diff)
+                if prev_normalized != new_normalized:
+                    logger.info(f"New best diff for {miner.name}: {new_normalized} (was {prev_normalized})")
+                    send_diff_alert(miner, r)
     
     logger.info(f"Completed polling cycle. Successful: {success_count}/{len(ENDPOINTS)}")
-    return success_count 
+    return success_count

--- a/bitaxe_sentry/sentry/settings_manager.py
+++ b/bitaxe_sentry/sentry/settings_manager.py
@@ -18,6 +18,7 @@ DEFAULT_SETTINGS = {
     "TEMP_MIN": 20,
     "TEMP_MAX": 70,
     "VOLT_MIN": 5.0,
+    "LATENCY_MAX_THRESHOLD": 500,
     "BITAXE_ENDPOINTS": [],
     "DISCORD_WEBHOOK_URL": ""
 }
@@ -54,10 +55,11 @@ def load_settings():
             settings["TEMP_MIN"] = float(settings["TEMP_MIN"])
             settings["TEMP_MAX"] = float(settings["TEMP_MAX"])
             settings["VOLT_MIN"] = float(settings["VOLT_MIN"])
+            settings["LATENCY_MAX_THRESHOLD"] = float(settings.get("LATENCY_MAX_THRESHOLD", DEFAULT_SETTINGS["LATENCY_MAX_THRESHOLD"]))
             
             # Log the converted values for debugging
             logger.info(f"Loaded settings - POLL_INTERVAL_MINUTES: {settings['POLL_INTERVAL_MINUTES']}, "
-                        f"VOLT_MIN: {settings['VOLT_MIN']}")
+                        f"VOLT_MIN: {settings['VOLT_MIN']}, LATENCY_MAX_THRESHOLD: {settings['LATENCY_MAX_THRESHOLD']}")
         except (ValueError, TypeError) as e:
             logger.error(f"Error converting settings values: {e}, using defaults")
             # Use defaults for any values that couldn't be converted
@@ -66,6 +68,7 @@ def load_settings():
             settings["TEMP_MIN"] = DEFAULT_SETTINGS["TEMP_MIN"]
             settings["TEMP_MAX"] = DEFAULT_SETTINGS["TEMP_MAX"]
             settings["VOLT_MIN"] = DEFAULT_SETTINGS["VOLT_MIN"]
+            settings["LATENCY_MAX_THRESHOLD"] = DEFAULT_SETTINGS["LATENCY_MAX_THRESHOLD"]
         
         return settings
     except Exception as e:
@@ -88,10 +91,11 @@ def save_settings(settings_dict):
         settings_dict["TEMP_MIN"] = float(settings_dict.get("TEMP_MIN", DEFAULT_SETTINGS["TEMP_MIN"]))
         settings_dict["TEMP_MAX"] = float(settings_dict.get("TEMP_MAX", DEFAULT_SETTINGS["TEMP_MAX"]))
         settings_dict["VOLT_MIN"] = float(settings_dict.get("VOLT_MIN", DEFAULT_SETTINGS["VOLT_MIN"]))
+        settings_dict["LATENCY_MAX_THRESHOLD"] = float(settings_dict.get("LATENCY_MAX_THRESHOLD", DEFAULT_SETTINGS["LATENCY_MAX_THRESHOLD"]))
         
         # Log the converted values for debugging
         logger.info(f"Saving settings - POLL_INTERVAL_MINUTES: {settings_dict['POLL_INTERVAL_MINUTES']}, "
-                    f"VOLT_MIN: {settings_dict['VOLT_MIN']}")
+                    f"VOLT_MIN: {settings_dict['VOLT_MIN']}, LATENCY_MAX_THRESHOLD: {settings_dict['LATENCY_MAX_THRESHOLD']}")
     except (ValueError, TypeError) as e:
         logger.error(f"Error converting settings values: {e}")
         return False

--- a/bitaxe_sentry/sentry/settings_manager.py
+++ b/bitaxe_sentry/sentry/settings_manager.py
@@ -19,6 +19,7 @@ DEFAULT_SETTINGS = {
     "TEMP_MAX": 70,
     "VOLT_MIN": 5.0,
     "LATENCY_MAX_THRESHOLD": 500,
+    "LATENCY_CONSECUTIVE_COUNT": 3,
     "BITAXE_ENDPOINTS": [],
     "DISCORD_WEBHOOK_URL": ""
 }
@@ -57,9 +58,19 @@ def load_settings():
             settings["VOLT_MIN"] = float(settings["VOLT_MIN"])
             settings["LATENCY_MAX_THRESHOLD"] = float(settings.get("LATENCY_MAX_THRESHOLD", DEFAULT_SETTINGS["LATENCY_MAX_THRESHOLD"]))
             
+            latency_consecutive = settings.get("LATENCY_CONSECUTIVE_COUNT", DEFAULT_SETTINGS["LATENCY_CONSECUTIVE_COUNT"])
+            try:
+                latency_consecutive = int(latency_consecutive)
+                if latency_consecutive < 1:
+                    latency_consecutive = DEFAULT_SETTINGS["LATENCY_CONSECUTIVE_COUNT"]
+            except (ValueError, TypeError):
+                latency_consecutive = DEFAULT_SETTINGS["LATENCY_CONSECUTIVE_COUNT"]
+            settings["LATENCY_CONSECUTIVE_COUNT"] = latency_consecutive
+            
             # Log the converted values for debugging
             logger.info(f"Loaded settings - POLL_INTERVAL_MINUTES: {settings['POLL_INTERVAL_MINUTES']}, "
-                        f"VOLT_MIN: {settings['VOLT_MIN']}, LATENCY_MAX_THRESHOLD: {settings['LATENCY_MAX_THRESHOLD']}")
+                        f"VOLT_MIN: {settings['VOLT_MIN']}, LATENCY_MAX_THRESHOLD: {settings['LATENCY_MAX_THRESHOLD']}, "
+                        f"LATENCY_CONSECUTIVE_COUNT: {settings['LATENCY_CONSECUTIVE_COUNT']}")
         except (ValueError, TypeError) as e:
             logger.error(f"Error converting settings values: {e}, using defaults")
             # Use defaults for any values that couldn't be converted
@@ -69,6 +80,7 @@ def load_settings():
             settings["TEMP_MAX"] = DEFAULT_SETTINGS["TEMP_MAX"]
             settings["VOLT_MIN"] = DEFAULT_SETTINGS["VOLT_MIN"]
             settings["LATENCY_MAX_THRESHOLD"] = DEFAULT_SETTINGS["LATENCY_MAX_THRESHOLD"]
+            settings["LATENCY_CONSECUTIVE_COUNT"] = DEFAULT_SETTINGS["LATENCY_CONSECUTIVE_COUNT"]
         
         return settings
     except Exception as e:
@@ -93,9 +105,19 @@ def save_settings(settings_dict):
         settings_dict["VOLT_MIN"] = float(settings_dict.get("VOLT_MIN", DEFAULT_SETTINGS["VOLT_MIN"]))
         settings_dict["LATENCY_MAX_THRESHOLD"] = float(settings_dict.get("LATENCY_MAX_THRESHOLD", DEFAULT_SETTINGS["LATENCY_MAX_THRESHOLD"]))
         
+        latency_consecutive = settings_dict.get("LATENCY_CONSECUTIVE_COUNT", DEFAULT_SETTINGS["LATENCY_CONSECUTIVE_COUNT"])
+        try:
+            latency_consecutive = int(latency_consecutive)
+            if latency_consecutive < 1:
+                latency_consecutive = DEFAULT_SETTINGS["LATENCY_CONSECUTIVE_COUNT"]
+        except (ValueError, TypeError):
+            latency_consecutive = DEFAULT_SETTINGS["LATENCY_CONSECUTIVE_COUNT"]
+        settings_dict["LATENCY_CONSECUTIVE_COUNT"] = latency_consecutive
+        
         # Log the converted values for debugging
         logger.info(f"Saving settings - POLL_INTERVAL_MINUTES: {settings_dict['POLL_INTERVAL_MINUTES']}, "
-                    f"VOLT_MIN: {settings_dict['VOLT_MIN']}, LATENCY_MAX_THRESHOLD: {settings_dict['LATENCY_MAX_THRESHOLD']}")
+                    f"VOLT_MIN: {settings_dict['VOLT_MIN']}, LATENCY_MAX_THRESHOLD: {settings_dict['LATENCY_MAX_THRESHOLD']}, "
+                    f"LATENCY_CONSECUTIVE_COUNT: {settings_dict['LATENCY_CONSECUTIVE_COUNT']}")
     except (ValueError, TypeError) as e:
         logger.error(f"Error converting settings values: {e}")
         return False

--- a/bitaxe_sentry/sentry/templates/dashboard.html
+++ b/bitaxe_sentry/sentry/templates/dashboard.html
@@ -132,6 +132,26 @@
                             </h5>
                         </div>
                     </div>
+                    <div class="col-6">
+                        <div class="mb-3">
+                            <h6 class="text-muted mb-1">Pool Latency</h6>
+                            <h5 class="
+                                {% if item.reading.response_time and item.reading.response_time > 500 %}
+                                    temp-danger
+                                {% elif item.reading.response_time and item.reading.response_time > 200 %}
+                                    temp-warning
+                                {% else %}
+                                    temp-normal
+                                {% endif %}
+                            ">
+                                {% if item.reading.response_time is not none %}
+                                {{ "%.1f"|format(item.reading.response_time) }} ms
+                                {% else %}
+                                <span class="text-muted">N/A</span>
+                                {% endif %}
+                            </h5>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="card-footer text-muted small">

--- a/bitaxe_sentry/sentry/templates/history.html
+++ b/bitaxe_sentry/sentry/templates/history.html
@@ -312,6 +312,47 @@
     </div>
 </div>
 
+<div class="row mb-4">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5>Pool Latency (ms)</h5>
+                <div class="chart-controls" id="latencyControls">
+                    <!-- Buttons will be generated dynamically by JavaScript -->
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="chart-container">
+                    <canvas id="latencyChart"></canvas>
+                </div>
+                <div class="chart-options">
+                    <div class="chart-options-group">
+                        <button class="btn btn-sm btn-light chart-toggle-btn active" id="latencyChartCurved" onclick="toggleCurvedLines('latencyChart', this)" title="Toggle Curved Lines">
+                            <i class="fas fa-bezier-curve"></i><span class="d-none d-md-inline"> Curved</span>
+                        </button>
+                        <button class="btn btn-sm btn-light chart-toggle-btn active" id="latencyChartPoints" onclick="toggleDataPoints('latencyChart', this)" title="Toggle Data Points">
+                            <i class="fas fa-circle"></i><span class="d-none d-md-inline"> Points</span>
+                        </button>
+                    </div>
+                    <div class="chart-options-group">
+                        <div class="dropdown d-inline-block">
+                            <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="latencyLegendDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Legend Position">
+                                <i class="fas fa-list"></i><span class="d-none d-md-inline"> Legend</span>
+                            </button>
+                            <ul class="dropdown-menu" aria-labelledby="latencyLegendDropdown">
+                                <li><a class="dropdown-item" href="#" onclick="changeLegendPosition('latencyChart', 'top'); return false;">Top</a></li>
+                                <li><a class="dropdown-item" href="#" onclick="changeLegendPosition('latencyChart', 'bottom'); return false;">Bottom</a></li>
+                                <li><a class="dropdown-item" href="#" onclick="changeLegendPosition('latencyChart', 'left'); return false;">Left</a></li>
+                                <li><a class="dropdown-item" href="#" onclick="changeLegendPosition('latencyChart', 'right'); return false;">Right</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Store the readings data for JavaScript -->
 <script id="readings-data" type="application/json">
 {{ readings_by_miner|tojson }}
@@ -337,6 +378,7 @@
     let tempChart = null;
     let voltageChart = null;
     let errorChart = null;
+    let latencyChart = null;
     
     // Global data storage
     let rawData = null;
@@ -349,6 +391,7 @@
         if (chartId === 'tempChart') return tempChart;
         if (chartId === 'voltageChart') return voltageChart;
         if (chartId === 'errorChart') return errorChart;
+        if (chartId === 'latencyChart') return latencyChart;
         return null;
     }
     
@@ -369,7 +412,7 @@
     
     // Generate time window buttons for all charts
     function generateTimeWindowButtons() {
-        const chartIds = ['hashRateControls', 'tempControls', 'voltageControls', 'errorControls'];
+        const chartIds = ['hashRateControls', 'tempControls', 'voltageControls', 'errorControls', 'latencyControls'];
         
         chartIds.forEach(chartId => {
             const container = document.getElementById(chartId);
@@ -428,7 +471,7 @@
         });
         
         // Update each chart
-        ['hashRateChart', 'tempChart', 'voltageChart', 'errorChart'].forEach(chartId => {
+        ['hashRateChart', 'tempChart', 'voltageChart', 'errorChart', 'latencyChart'].forEach(chartId => {
             updateChartFromSlice(chartId, dataSlice);
         });
     }
@@ -501,6 +544,7 @@
                     y: chartId === 'hashRateChart' ? convertHashrate(r.hash_rate)
                         : chartId === 'tempChart' ? r.temperature
                         : chartId === 'voltageChart' ? r.voltage
+                        : chartId === 'latencyChart' ? (r.response_time || 0)
                         : /* errorChart */ (r.error_percentage || 0),
                     rawTimestamp: r.timestamp // Store the raw timestamp for display
                 };
@@ -772,6 +816,30 @@
                             title: {
                                 display: true,
                                 text: '%'
+                            }
+                        }
+                    }
+                }
+            });
+        }
+        
+        // Initialize Latency chart
+        const latencyCtx = document.getElementById('latencyChart');
+        if (latencyCtx) {
+            latencyChart = new Chart(latencyCtx, {
+                type: 'line',
+                data: {
+                    datasets: []
+                },
+                options: {
+                    ...commonOptions,
+                    scales: {
+                        ...commonOptions.scales,
+                        y: {
+                            beginAtZero: true,
+                            title: {
+                                display: true,
+                                text: 'ms'
                             }
                         }
                     }

--- a/bitaxe_sentry/sentry/templates/settings.html
+++ b/bitaxe_sentry/sentry/templates/settings.html
@@ -70,6 +70,12 @@
                                value="{{ settings.LATENCY_MAX_THRESHOLD }}" min="100" max="5000" step="50" required>
                         <div class="form-text">Maximum acceptable pool response time before alerting (100-5000 ms)</div>
                     </div>
+                    <div class="mb-3">
+                        <label for="latency_consecutive" class="form-label">Consecutive High Latency Count</label>
+                        <input type="number" class="form-control" id="latency_consecutive" name="LATENCY_CONSECUTIVE_COUNT" 
+                               value="{{ settings.LATENCY_CONSECUTIVE_COUNT }}" min="1" step="1" required>
+                        <div class="form-text">Number of consecutive high latency readings before alerting</div>
+                    </div>
                 </div>
             </div>
             

--- a/bitaxe_sentry/sentry/templates/settings.html
+++ b/bitaxe_sentry/sentry/templates/settings.html
@@ -64,6 +64,12 @@
                                value="{{ settings.VOLT_MIN }}" min="3" max="12" step="0.1" required>
                         <div class="form-text">Minimum acceptable voltage before alerting</div>
                     </div>
+                    <div class="mb-3">
+                        <label for="latency_max" class="form-label">Maximum Latency Threshold (ms)</label>
+                        <input type="number" class="form-control" id="latency_max" name="LATENCY_MAX_THRESHOLD" 
+                               value="{{ settings.LATENCY_MAX_THRESHOLD }}" min="100" max="5000" step="50" required>
+                        <div class="form-text">Maximum acceptable pool response time before alerting (100-5000 ms)</div>
+                    </div>
                 </div>
             </div>
             

--- a/bitaxe_sentry/sentry/version.py
+++ b/bitaxe_sentry/sentry/version.py
@@ -2,4 +2,4 @@
 Bitaxe Sentry version information.
 """
 
-__version__ = "0.6.1" 
+__version__ = "0.7.0" 

--- a/bitaxe_sentry/sentry/webapp.py
+++ b/bitaxe_sentry/sentry/webapp.py
@@ -178,6 +178,11 @@ def history(
             error_percentage = reading.error_percentage if hasattr(reading, 'error_percentage') else 0.0
             if error_percentage is None:
                 error_percentage = 0.0
+            
+            # Ensure response_time has a default value if it's None
+            response_time = reading.response_time if hasattr(reading, 'response_time') else None
+            if response_time is None:
+                response_time = None
                 
             readings_by_miner[miner.name].append({
                 "timestamp": reading.timestamp.strftime("%H:%M:%S"),
@@ -186,7 +191,8 @@ def history(
                 "temperature": reading.temperature,
                 "best_diff": format_large_number(reading.best_diff),
                 "voltage": voltage,
-                "error_percentage": error_percentage
+                "error_percentage": error_percentage,
+                "response_time": response_time
             })
     
     # Pre-slice the data for different time windows

--- a/bitaxe_sentry/sentry/webapp.py
+++ b/bitaxe_sentry/sentry/webapp.py
@@ -114,6 +114,7 @@ def dashboard(request: Request, success: Optional[str] = None, error: Optional[s
     last_updated = most_recent_timestamp.strftime("%Y-%m-%d %H:%M:%S") if most_recent_timestamp else "Never"
     
     return templates.TemplateResponse(
+        request,
         "dashboard.html", 
         get_template_context(request, {
             "readings": latest_readings,
@@ -250,6 +251,7 @@ def history(
                 logger.info(f"Window {hours}h for {miner_name}: No data points")
     
     return templates.TemplateResponse(
+        request,
         "history.html", 
         get_template_context(request, {
             "miners": miners,
@@ -326,7 +328,7 @@ def settings_page(request: Request, success: Optional[str] = None, error: Option
         "error_message": error
     }
     
-    return templates.TemplateResponse("settings.html", get_template_context(request, context))
+    return templates.TemplateResponse(request, "settings.html", get_template_context(request, context))
 
 def notify_sentry_service():
     """Send SIGHUP signal to the sentry service to reload configuration"""


### PR DESCRIPTION
Hi again. This is the recreation of the previous PR i made. Now coming from a feature branch on my forked repo.

 I wanted to see pool latency as I switched from remote to a local umbrel server. I've been running my version for a month now to check its all working. I have found it useful to know if I ever use my fall back that will mean the latency is higher or any network troubles

<img width="433" height="241" alt="image" src="https://github.com/user-attachments/assets/3cc02793-d7ec-416a-803e-dd03af6982e1" />

A new addition i added was a consecutive count as i noticed when my node was creating a block there would be higher latency which is normal. I didn't want to get a notification if the latency increased due to that. I only wanted a notification if there is an ongoing problem with high latency.

<img width="1300" height="454" alt="setting-latency" src="https://github.com/user-attachments/assets/59248f8e-9c39-4955-9a4d-4a6447da40dc" />

I have this version pushed to docker hub if you want to try it

`docker pull stephenor/bitaxe-sentry:0.2.0`

